### PR TITLE
Fix for 'modern' Linux kernels. Replace timespec with timespec64 (no …

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,8 @@ else
 all: modules test
 
 modules:
-	${MAKE} -C ${KERNEL_DIR} SUBDIRS=${MODULE_DIR}  modules 
+#	${MAKE} -C ${KERNEL_DIR} SUBDIRS=${MODULE_DIR}  modules 
+	${MAKE} -C ${KERNEL_DIR} M=${MODULE_DIR}  modules 
 
 clean:
 	rm -f *.o *.ko *.mod.c .*.o .*.ko .*.mod.c .*.cmd *~ test

--- a/Readme.md
+++ b/Readme.md
@@ -7,7 +7,7 @@ Reading the GPIO interrupt timestamps is somewhat peculiar:
 
 - read() is non-blocking: if no interrupts have occurred you simply get a zero return
 - by default you do not read characters, you read timestamps: the length parameter in read() specifies the number of timestamps you want to read. So your buffer size must be a multiple of sizeof(timespec64), which is normally 12 bytes on 32-bit architecture, and 16 bytes on 64 bit architectures.  
-When you us the `safemode=1` parameter on module installation the length parameter in read() specifies the number of bytes to read. In this mode the length parameter must be a multiple of sizeof(timespec64). The safe mode makes it possible to access the kernel module interface from environments like Python.
+When you use the `safemode=1` parameter on module installation the length parameter in read() specifies the number of bytes to read. In this mode the length parameter must be a multiple of sizeof(timespec64). The safe mode makes it possible to access the kernel module interface from environments like Python.
 - by default read() returns the number of timespec structs read, not the number of bytes.  
 When `safemode` is active the number of bytes read is returned.
 - you should use poll() before you try to read() if you want to avoid reading in a loop until GPIO interrupts arrive

--- a/Readme.md
+++ b/Readme.md
@@ -6,8 +6,10 @@ including a character device driver for reading the timestamped interrupts
 Reading the GPIO interrupt timestamps is somewhat peculiar:
 
 - read() is non-blocking: if no interrupts have occurred you simply get a zero return
-- you do not read characters, you read timestamps: the length parameter in read() specifies the number of timestamps you want to read. So your buffer size must be a multiple of sizeof(timespec), which is normally 8 bytes on 32-bit architecture, and 16 bytes on 64 bit architectures.
-- read() returns the number of timespec structs read, not the number of bytes
+- by default you do not read characters, you read timestamps: the length parameter in read() specifies the number of timestamps you want to read. So your buffer size must be a multiple of sizeof(timespec64), which is normally 12 bytes on 32-bit architecture, and 16 bytes on 64 bit architectures.  
+When you us the `safemode=1` parameter on module installation the length parameter in read() specifies the number of bytes to read. In this mode the length parameter must be a multiple of sizeof(timespec64). The safe mode makes it possible to access the kernel module interface from environments like Python.
+- by default read() returns the number of timespec structs read, not the number of bytes.  
+When `safemode` is active the number of bytes read is returned.
 - you should use poll() before you try to read() if you want to avoid reading in a loop until GPIO interrupts arrive
 - if no gpiots*x* device is open, GPIO interrupts for that GPIO are ignored and are not buffered
 - the default fifo buffer size in the kernel module is 128 timespec structs for each GPIO, but you can change this default by modifying the following define in the source of *gpio_stamp.c*:
@@ -17,5 +19,5 @@ Reading the GPIO interrupt timestamps is somewhat peculiar:
 `
 
 - if the fifo buffer overflows the driver will log it, but otherwise you'll never know
-- the module has a single array parameter on install: `gpios=n1,n2,...` which lists the GPIO pins you want to monitor
+- the module has an array parameter on install: `gpios=1,2,...` which lists the GPIO pins you want to monitor
 

--- a/client/Makefile
+++ b/client/Makefile
@@ -1,0 +1,8 @@
+all: client
+
+clean:
+	rm -f *.o gpiots_client gpiots_client_safe
+
+client: gpiots_client.c gpiots_client_safe.c
+	$(CC) -o gpiots_client gpiots_client.c
+	$(CC) -o gpiots_client_safe gpiots_client_safe.c

--- a/client/gpiots_client.c
+++ b/client/gpiots_client.c
@@ -1,0 +1,102 @@
+/*
+Licensed under The MIT License (MIT)
+
+Copyright (c) 2021 Diamino
+
+This client is an adaptation of the gpiots example of Danny Heijl
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+#include <fcntl.h>
+#include <poll.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+
+#define NGPIOS 3
+//int gpios[] = {9, 10, 11};
+
+typedef int64_t time64_t;
+struct timespec64 {
+	time64_t	tv_sec;			/* seconds */
+	long		tv_nsec;		/* nanoseconds */
+};
+
+void timespecsub(struct timespec64 *a, struct timespec64 *b, struct timespec64 *result) {
+    result->tv_sec  = a->tv_sec  - b->tv_sec;
+    result->tv_nsec = a->tv_nsec - b->tv_nsec;
+    if (result->tv_nsec < 0) {
+        --result->tv_sec;
+        result->tv_nsec += 1000000000L;
+    }
+}
+
+int main(int argc, char **argv) {
+    setbuf(stdout, NULL); // Disable output buffering
+
+    struct timespec64 ts[NGPIOS], prevts[NGPIOS], deltats[NGPIOS];
+    int fd[NGPIOS];
+    struct pollfd pfds[NGPIOS];
+    
+    for (int i = 0; i < NGPIOS; i++) {
+        char gpiofile[64];
+        snprintf(gpiofile, 64, "/dev/gpiots%d", i);
+        fd[i] = open(gpiofile, O_RDONLY);
+        if (fd[i] < 0) {
+            fprintf(stderr, "%s open error %d\n", gpiofile, fd[i]);
+            exit(-1);
+        }
+        pfds[i].fd = fd[i];
+        pfds[i].events = POLLPRI | POLLERR;
+    }
+
+    int n;
+    while (true) {
+        int rc = poll(pfds, NGPIOS, 2000);
+        if (rc < 0) { // error
+            perror("poll failed");
+            return -1;
+        }
+        if (rc == 0) { // timeout
+            fprintf(stderr, "poll timeout\n");
+            continue;
+        }
+        for (int i = 0; i < NGPIOS; i++) {
+            if (pfds[i].revents != 0) {
+                n = read(fd[i], &ts[i], 1);
+                if (n==1) {
+                    printf("%d,%lld,%ld\n", i, ts[i].tv_sec, ts[i].tv_nsec);
+                    fprintf(stderr, " [%d] %lld secs %ld nsecs\n", i, ts[i].tv_sec, ts[i].tv_nsec);
+                    timespecsub(&ts[i], &prevts[i], &deltats[i]);
+                    fprintf(stderr," [%d]   delta: %lld secs %ld nsecs\n", i, deltats[i].tv_sec, deltats[i].tv_nsec);
+                    prevts[i] = ts[i];   
+                } else {
+                    fprintf(stderr, "************** read failed for fd%d\n", i);
+                    continue;
+                }
+            }
+        }
+    }
+    for (int i = 0; i < NGPIOS; i++) {
+        close(fd[i]);
+    }
+    exit(0);
+}

--- a/client/gpiots_client_safe.c
+++ b/client/gpiots_client_safe.c
@@ -1,0 +1,103 @@
+/*
+Licensed under The MIT License (MIT)
+
+Copyright (c) 2021 Diamino
+
+This client is an adaptation of the gpiots example of Danny Heijl
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+#include <fcntl.h>
+#include <poll.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+
+#define NGPIOS 3
+//int gpios[] = {9, 10, 11};
+
+typedef int64_t time64_t;
+struct timespec64 {
+	time64_t	tv_sec;			/* seconds */
+	long		tv_nsec;		/* nanoseconds */
+};
+
+// void timespecsub(struct timespec64 *a, struct timespec64 *b, struct timespec64 *result) {
+//     result->tv_sec  = a->tv_sec  - b->tv_sec;
+//     result->tv_nsec = a->tv_nsec - b->tv_nsec;
+//     if (result->tv_nsec < 0) {
+//         --result->tv_sec;
+//         result->tv_nsec += 1000000000L;
+//     }
+// }
+
+int main(int argc, char **argv) {
+    setbuf(stdout, NULL); // Disable output buffering
+
+    struct timespec64 ts[NGPIOS];
+    //struct timespec64 prevts[NGPIOS], deltats[NGPIOS];
+    int fd[NGPIOS];
+    struct pollfd pfds[NGPIOS];
+    
+    for (int i = 0; i < NGPIOS; i++) {
+        char gpiofile[64];
+        snprintf(gpiofile, 64, "/dev/gpiots%d", i);
+        fd[i] = open(gpiofile, O_RDONLY);
+        if (fd[i] < 0) {
+            fprintf(stderr, "%s open error %d\n", gpiofile, fd[i]);
+            exit(-1);
+        }
+        pfds[i].fd = fd[i];
+        pfds[i].events = POLLPRI | POLLERR;
+    }
+
+    int n;
+    while (true) {
+        int rc = poll(pfds, NGPIOS, 2000);
+        if (rc < 0) { // error
+            perror("poll failed");
+            return -1;
+        }
+        if (rc == 0) { // timeout
+            fprintf(stderr, "poll timeout\n");
+            continue;
+        }
+        for (int i = 0; i < NGPIOS; i++) {
+            if (pfds[i].revents != 0) {
+                n = read(fd[i], &ts[i], sizeof(struct timespec64));
+                if (n==sizeof(struct timespec64)) {
+                    printf("%d,%lld,%ld\n", i, ts[i].tv_sec, ts[i].tv_nsec);
+                    fprintf(stderr, " [%d] %lld secs %ld nsecs\n", i, ts[i].tv_sec, ts[i].tv_nsec);
+                    //timespecsub(&ts[i], &prevts[i], &deltats[i]);
+                    //fprintf(stderr," [%d]   delta: %lld secs %ld nsecs\n", i, deltats[i].tv_sec, deltats[i].tv_nsec);
+                    //prevts[i] = ts[i];   
+                } else {
+                    fprintf(stderr, "************** read failed for fd%d\n", i);
+                    continue;
+                }
+            }
+        }
+    }
+    for (int i = 0; i < NGPIOS; i++) {
+        close(fd[i]);
+    }
+    exit(0);
+}

--- a/fifo_payload.h
+++ b/fifo_payload.h
@@ -1,12 +1,18 @@
 #ifndef _FIFO_PAYLOAD_
 #define _FIFO_PAYLOAD_
 
-#include <time.h>
+#include <stdint.h>
+
+typedef int64_t time64_t;
+struct timespec64 {
+	time64_t	tv_sec;			/* seconds */
+	long		tv_nsec;		/* nanoseconds */
+};
 
 typedef struct FIFO_PAYLOAD_T {
     int lusid;
-    struct timespec ts_start;
-    struct timespec ts_end;
+    struct timespec64 ts_start;
+    struct timespec64 ts_end;
 } fifo_payload_t;
 
 #endif // _FIFO_PAYLOAD_

--- a/gpiots_fifo.c
+++ b/gpiots_fifo.c
@@ -39,7 +39,7 @@ gpio_fifo_t *gpio_fifo_create(int size) {
     f->head = 0;
     f->tail = 0;
     f->size = size + 1;
-    f->data = (struct timespec *)kmalloc((size + 1) * sizeof(struct timespec), GFP_KERNEL);
+    f->data = (struct timespec64 *)kmalloc((size + 1) * sizeof(struct timespec64), GFP_KERNEL);
     if (f->data == NULL) {
         printk(KERN_ERR "fifo_create: out of memory\n");
         return NULL;
@@ -58,9 +58,9 @@ void gpio_fifo_destroy(gpio_fifo_t *f) {
 }
 // This reads up to n timestamps from the FIFO
 // The number of timestamps actually read is returned
-int gpio_fifo_read(gpio_fifo_t *f, struct timespec *data, int ntimestamps) {
+int gpio_fifo_read(gpio_fifo_t *f, struct timespec64 *data, int ntimestamps) {
     int i;
-    struct timespec *p = data;
+    struct timespec64 *p = data;
     for (i = 0; i < ntimestamps; i++) {
         if (f->tail != f->head) {     // see if any data is available
             *p++ = f->data[f->tail];  // grab a timestamp from the buffer
@@ -77,9 +77,9 @@ int gpio_fifo_read(gpio_fifo_t *f, struct timespec *data, int ntimestamps) {
 // This writes up to n timestamps to the FIFO
 // If the head runs in to the tail, not all timestamps are written
 // The number of timestamps actually written is returned
-int gpio_fifo_write(gpio_fifo_t *f, const struct timespec *data, int ntimestamps) {
+int gpio_fifo_write(gpio_fifo_t *f, const struct timespec64 *data, int ntimestamps) {
     int i;
-    const struct timespec *p;
+    const struct timespec64 *p;
     p = data;
     for (i = 0; i < ntimestamps; i++) {
         // first check to see if there is space in the buffer

--- a/gpiots_fifo.h
+++ b/gpiots_fifo.h
@@ -33,7 +33,7 @@ SOFTWARE.
 #define RT_CLOCK CLOCK_REALTIME
 
 typedef struct GPIO_FIFO_T {
-    struct timespec *data;
+    struct timespec64 *data;
     int head;
     int tail;
     int size;
@@ -42,8 +42,8 @@ typedef struct GPIO_FIFO_T {
 gpio_fifo_t *gpio_fifo_create(int size);
 void gpio_fifo_destroy(gpio_fifo_t *f);
 
-int gpio_fifo_read(gpio_fifo_t *f, struct timespec *data, int ntimestamps);
-int gpio_fifo_write(gpio_fifo_t *f, const struct timespec *data, int ntimestamps);
+int gpio_fifo_read(gpio_fifo_t *f, struct timespec64 *data, int ntimestamps);
+int gpio_fifo_write(gpio_fifo_t *f, const struct timespec64 *data, int ntimestamps);
 bool gpio_fifo_data_available(gpio_fifo_t *f);
 void gpio_fifo_clear(gpio_fifo_t *f);
 

--- a/gpiots_test.c
+++ b/gpiots_test.c
@@ -37,11 +37,11 @@ SOFTWARE.
 
 int main(int argc, char **argv) {
 
-    struct timespec ts;
+    struct timespec64 ts;
     fifo_payload_t lus[LUSSEN];
     for (int i = 0; i < LUSSEN; ++i) {
         lus[i].lusid = i;
-        lus[i].ts_start = lus[i].ts_end = (struct timespec) { 0, 0 }; 
+        lus[i].ts_start = lus[i].ts_end = (struct timespec64) { 0, 0 }; 
     }
     int files[NGPIOS];
     for (int i = 0; i < NGPIOS; ++i) {
@@ -98,7 +98,7 @@ int main(int argc, char **argv) {
                 } else {
                     printf("lus %d: ***interrupts arrived out of order\n", lus[i].lusid);               
                 }
-                lus[i].ts_start = lus[i].ts_end = (struct timespec){ 0, 0 };
+                lus[i].ts_start = lus[i].ts_end = (struct timespec64){ 0, 0 };
             }
            
         }


### PR DESCRIPTION
Timespec and related functions are removed from recent kernel versions. I fixed the kernel module to use the newer 64-bit version of timespec that won't overflow in 2038.